### PR TITLE
fixed i2c address for servo controller.  tested pwm works now.

### DIFF
--- a/nxt/sensor/hitechnic.py
+++ b/nxt/sensor/hitechnic.py
@@ -474,7 +474,7 @@ the sensor but not tested. Please report whether this worked for you or not!"""
         'p4pos': (0x45, 'B'),
         'p5pos': (0x46, 'B'),
         'p6pos': (0x47, 'B'),
-        'pwm': (0x46, 'B'),
+        'pwm': (0x48, 'B'),
     })
     
     class Status:


### PR DESCRIPTION
I tried running my servo controller for the first time, but the hitechnic servo controller documentation said the pwm had to be turned on first.  Couldn't use the set pwm function because of the wrong address! servo controller totally works now.  So does the motor controller by the way, which doesn't seem to need any corrections so far that I've used it. Wish I could daisy chain the controllers, but it's great on its own!  Really love your work here, it's made my life a whole lot easier.