### PR TITLE
Fix for type errors in Python3 and fix for bluesock

### DIFF
--- a/nxt/bluesock.py
+++ b/nxt/bluesock.py
@@ -51,12 +51,15 @@ class BlueSock(object):
             print('Bluetooth connection closed.')
 
     def send(self, data):
+        data = bytes(data)
+        l0 = len(data) & 0xFF
+        l1 = (len(data) >> 8) & 0xFF
+        d = [l0, l1]
+        for item in data:
+            d.append(item)
+        d = bytes(d)
         if self.debug:
-            print('Send:', end=' ')
-            print(':'.join('%02x' % ord(c) for c in data))
-        l0 = len(data.encode('utf-8')) & 0xFF
-        l1 = (len(data.encode('utf-8')) >> 8) & 0xFF
-        d = chr(l0) + chr(l1) + data
+            print('Sending byte: ' + str(data))
         self.sock.send(d)
 
     def recv(self):

--- a/nxt/locator.py
+++ b/nxt/locator.py
@@ -121,7 +121,8 @@ name, strict, or method) are provided."""
         print("Host: %s Name: %s Strict: %s" % (host, name, str(strict)))
         print("USB: %s BT: %s Fantom: %s FUSB: %s FBT: %s" % (method.usb, method.bluetooth, method.fantom, method.fantomusb, method.fantombt))
 
-    for s in find_bricks(host, name, silent, method):
+        for s in find_bricks(host, name, silent, method):
+        print('Point Reached')
         try:
             if host and 'host' in dir(s) and s.host != host:
                 if debug:
@@ -129,6 +130,8 @@ name, strict, or method) are provided."""
                 if strict: continue
             b = s.connect()
             info = b.get_device_info()
+            print(info)
+            strict = False
             if host and info[1] != host:
                 if debug:
                     print("Warning: the brick found does not match the host provided (get_device_info).")
@@ -136,14 +139,9 @@ name, strict, or method) are provided."""
                     s.close()
                     continue
             info = list(info)
-            info[0] = 'Computer'
             info[0] = str(info[0])
             info[0] = info[0][2:(len(info[0])-1)]
-            print('Info[0] is {}'.format(info[0]))
             info[0] = info[0].strip('\\x00')
-            print('Info[0] is {}'.format(info[0]))
-            # /\ Inserted
-            print('Name parsed is {}'.format(name))
             if info[0] != name:
                 if debug:
                     print("Warning; the brick found does not match the name provided.")


### PR DESCRIPTION
The addition to `locator.py` is just to clean up some code that I put an issue in before, I believe this should work better.

The change in the `send()` method in `bluesock.py` uses bytes to create the packet instead of the previous method which used a conversion to unicode, this fixes a number of errors and should be easier to use later on.

I believe my changes will update this flawlessly for python3 in the parts I have tested, I haven't found any problems yet.

Thanks in advance, Goldsloth