### PR TITLE
[WIP] Remove .split['\0'][0] because it is not needed

### DIFF
--- a/nxt/sensor/digital.py
+++ b/nxt/sensor/digital.py
@@ -152,9 +152,9 @@ suppressed by passing "check_compatible=False" when creating the sensor object."
         self._i2c_command(address, value, fmt)
     
     def get_sensor_info(self):
-        version = self.read_value('version')[0].decode('windows-1252').split('\0')[0]
-        product_id = self.read_value('product_id')[0].decode('windows-1252').split('\0')[0]
-        sensor_type = self.read_value('sensor_type')[0].decode('windows-1252').split('\0')[0]
+        version = self.read_value('version')[0].decode('windows-1252')
+        product_id = self.read_value('product_id')[0].decode('windows-1252')
+        sensor_type = self.read_value('sensor_type')[0].decode('windows-1252')
         return SensorInfo(version, product_id, sensor_type)
         
     @classmethod

--- a/nxt/sensor/generic.py
+++ b/nxt/sensor/generic.py
@@ -100,9 +100,9 @@ class Ultrasonic(BaseDigitalSensor):
         return self.read_value('measurement_byte_0')[0]
     
     get_sample = get_distance
-            
+
     def get_measurement_units(self):
-        return self.read_value('measurement_units')[0].decode('windows-1252').split('\0')[0]
+        return self.read_value('measurement_units')[0].decode('windows-1252')
 
     def get_all_measurements(self):
         "Returns all the past readings in measurement_byte_0 through 7"


### PR DESCRIPTION
This is a work in progress (WIP).

Those are all occurances where .split['\0'][0] is used after .decode('windows-1252'). In the other code the split is not needed. Maybe the split can also be removed here. But I am not sure because I have no sensors to try.