### PR TITLE
fix TypeError when connecting via Bluetooth

### DIFF
--- a/nxt/bluesock.py
+++ b/nxt/bluesock.py
@@ -64,13 +64,13 @@ class BlueSock(object):
 
     def recv(self):
         data = self.sock.recv(2)
-        l0 = ord(data[0])
-        l1 = ord(data[1])
+        l0 = data[0]
+        l1 = data[1]
         plen = l0 + (l1 << 8)
         data = self.sock.recv(plen)
         if self.debug:
             print('Recv:', end=' ')
-            print(':'.join('%02x' % ord(c) for c in data))
+            print(':'.join('%02x' % c for c in data))
         return data
 
 def _check_brick(arg, value):


### PR DESCRIPTION
This fixes the error:

    TypeError: ord() expected string of length 1, but int found

when connecting via Bluetooth

Tested working on Linux.

Closes #124