### PR TITLE
don't use eval() for parsing method in config file

### DIFF
--- a/nxt/locator.py
+++ b/nxt/locator.py
@@ -99,7 +99,10 @@ name, strict, or method) are provided."""
         host	= conf.get('Brick', 'host')
         name	= conf.get('Brick', 'name')
         strict	= bool(int(conf.get('Brick', 'strict')))
-        method	= eval('Method(%s)' % conf.get('Brick', 'method'))
+        methods = map(lambda x: x.strip().split('='),
+                      conf.get('Brick', 'method').split(','))
+        method = Method(**{k: v == 'True' for k, v in methods
+                           if k in ('bluetooth', 'usb', 'device')})
     if not strict: strict = True
     if not method: method = Method()
 


### PR DESCRIPTION
This improves the config file parsing of the method property. It fixes
possible code injection via eval() as well as makes parsing a bit more
robust by filtering out invalid values, such as the obsolete fantom
driver values.

Fixes #137