### PR TITLE
fix off by one in I2C error message

### DIFF
--- a/nxt/sensor/digital.py
+++ b/nxt/sensor/digital.py
@@ -73,7 +73,7 @@ class BaseDigitalSensor(Sensor):
             sensor = self.get_sensor_info()
             if not sensor in self.compatible_sensors:
                 print(('WARNING: Wrong sensor class chosen for sensor ' +
-                          str(sensor.product_id) + ' on port ' + str(port) + '. ' + """
+                          str(sensor.product_id) + ' on port ' + str(port + 1) + '. ' + """
 You may be using the wrong type of sensor or may have connected the cable
 incorrectly. If you are sure you're using the correct sensor class for the
 sensor, this message is likely in error and you should disregard it and file a


### PR DESCRIPTION
The port numbers (PORT_* values) are 0-based, however the actual port
numbers printed on the NXT are 1-based. So, add one so that the user
sees the port number printed on the NXT.