### PR TITLE
fix crash when no config file

### DIFF
--- a/nxt/locator.py
+++ b/nxt/locator.py
@@ -99,10 +99,12 @@ name, strict, or method) are provided."""
         host	= conf.get('Brick', 'host')
         name	= conf.get('Brick', 'name')
         strict	= bool(int(conf.get('Brick', 'strict')))
-        methods = map(lambda x: x.strip().split('='),
-                      conf.get('Brick', 'method').split(','))
-        method = Method(**{k: v == 'True' for k, v in methods
-                           if k in ('bluetooth', 'usb', 'device')})
+        method_value = conf.get('Brick', 'method')
+        if method_value:
+            methods = map(lambda x: x.strip().split('='),
+                          method_value.split(','))
+            method = Method(**{k: v == 'True' for k, v in methods
+                               if k in ('bluetooth', 'usb', 'device')})
     if not strict: strict = True
     if not method: method = Method()
 


### PR DESCRIPTION
This fixes an exception when there is not config file. The changes from commit cad30b1a6e02914c3e69cb6a017a052e334bce78 introduced this error.