### PR TITLE
Fix TypeError when using devsock connection

### DIFF
--- a/nxt/devsock.py
+++ b/nxt/devsock.py
@@ -31,13 +31,13 @@ class DeviceSocket:
     def send(self, data):
         l0 = len(data) & 0xFF
         l1 = (len(data) >> 8) & 0xFF
-        d = chr(l0) + chr(l1) + data
+        d = bytes((l0, l1)) + data
         self._device.write(d)
 
     def recv(self):
         data = self._device.read(2)
-        l0 = ord(data[0])
-        l1 = ord(data[1])
+        l0 = data[0]
+        l1 = data[1]
         plen = l0 + (l1 << 8)
         return self._device.read(plen)
 


### PR DESCRIPTION
This fixes a TypeError (probably caused by python 2>3 conversion) using the devsock connection on macOS.