### PR TITLE
Set generic light sensor illumination in init method

### DIFF
--- a/nxt/sensor/generic.py
+++ b/nxt/sensor/generic.py
@@ -37,6 +37,7 @@ class Light(BaseAnalogSensor):
     """
     def __init__(self, brick, port, illuminated=True):
         super(Light, self).__init__(brick, port)
+        self.set_illuminated(illuminated)
 
     def set_illuminated(self, active):
         if active:


### PR DESCRIPTION
Light sensor illumination is currently not being set by the init method